### PR TITLE
An idea for announcing upcoming events

### DIFF
--- a/_includes/meetup.html
+++ b/_includes/meetup.html
@@ -3,8 +3,8 @@
 		<div id="meetup-widget"></div>
 		{% raw %}
 		<script type="x-tmpl-mustache" id="meetup-widget-template">
+		<h2>Join Us at our Next Event</h2>
 			{{#results}}
-			<h2>Join Us at our Next Event</h2>
 			<div class="meetup-row flex-container flex-column">
 				<a class="url" href="{{event_url}}" target="_blank">{{name}}</a>
 				<div class="flex-item">

--- a/_includes/meetup.html
+++ b/_includes/meetup.html
@@ -3,25 +3,31 @@
 		<div id="meetup-widget"></div>
 		{% raw %}
 		<script type="x-tmpl-mustache" id="meetup-widget-template">
-		<h2>Join Us at our Next Event</h2>
+			<h2>Join Us at our Next Event</h2>
 			{{#results}}
-			<div class="meetup-row flex-container flex-column">
-				<a class="url" href="{{event_url}}" target="_blank">{{name}}</a>
-				<div class="flex-item">
-					<div class="meetup-cal">
+			<div class="meetup-row flex-container">
+				<div class="meetup-calendar">
+					<div class="meetup-cal-container">
 						<div class="meetup-month">{{month}}</div>
 						<div class="meetup-cal-body">
 							<div class="meetup-day">{{day}}</div>
 							<div class="meetup-weekday">{{weekday}}</div>
 						</div>
 					</div>
-					<div class="description">
-						<div class="text">{{{description}}}</div>
-					</div>
 				</div>
-				<div class="rsvp">
-					<span class="count">{{yes_rsvp_count}} RSVPs</span>
-					<a href="{{event_url}}" target="_blank">RSVP on Meetup.com</a>
+				<div class="flex-item">
+					<div class="meetup-details">
+						<div class="date">{{prettyDate}}</div>
+						<a class="url" href="{{event_url}}" target="_blank">{{name}}</a>
+						<div class="description">
+							<div class="text">{{{description}}}</div>
+							<div class="fade-out"></div>
+						</div>
+						<div class="rsvp">
+							<a href="{{event_url}}" target="_blank">RSVP on Meetup.com</a>
+							<span class="count">{{yes_rsvp_count}} RSVPs</span>
+						</div>
+					</div>
 				</div>
 			</div>
 			{{/results}}

--- a/_includes/meetup.html
+++ b/_includes/meetup.html
@@ -1,24 +1,33 @@
 <div class="upcoming-events post-content">
-	<div id="meetup-widget"></div>
-	{% raw %}
-	<script type="x-tmpl-mustache" id="meetup-widget-template">
-		<h2>Join Us</h2>
-		{{#results}}
-		<div class="meetup-row">
-			<a class="url" href="{{event_url}}" target="_blank">{{name}}</a>
-			<div class="date">{{prettyDate}}</div>
-			<div class="description">
-				<div class="text">{{{description}}}</div>
-				<div class="fade-out"></div>
+	<div class="wrapper">
+		<div id="meetup-widget"></div>
+		{% raw %}
+		<script type="x-tmpl-mustache" id="meetup-widget-template">
+			{{#results}}
+			<h2>Join Us at our Next Event</h2>
+			<div class="meetup-row flex-container flex-column">
+				<a class="url" href="{{event_url}}" target="_blank">{{name}}</a>
+				<div class="flex-item">
+					<div class="meetup-cal">
+						<div class="meetup-month">{{month}}</div>
+						<div class="meetup-cal-body">
+							<div class="meetup-day">{{day}}</div>
+							<div class="meetup-weekday">{{weekday}}</div>
+						</div>
+					</div>
+					<div class="description">
+						<div class="text">{{{description}}}</div>
+					</div>
+				</div>
+				<div class="rsvp">
+					<span class="count">{{yes_rsvp_count}} RSVPs</span>
+					<a href="{{event_url}}" target="_blank">RSVP on Meetup.com</a>
+				</div>
 			</div>
-			<div class="rsvp">
-				<span class="count">{{yes_rsvp_count}} RSVPs</span>
-				<a href="{{event_url}}" target="_blank">RSVP on Meetup.com</a>
-			</div>
-		</div>
-		{{/results}}
-	</script>
-	{% endraw %}
-	<script src="{{ site.baseurl }}/assets/js/mustache.min.js"></script>
-	<script src="{{ site.baseurl }}/assets/js/meetup.js"></script>
+			{{/results}}
+		</script>
+		{% endraw %}
+		<script src="{{ site.baseurl }}/assets/js/mustache.min.js"></script>
+		<script src="{{ site.baseurl }}/assets/js/meetup.js"></script>
+	</div>
 </div>

--- a/_sass/_buttons.scss
+++ b/_sass/_buttons.scss
@@ -12,6 +12,7 @@
     }
 }
 
+// TODO this could be refactored into a mixin...
 .btn-experiment-project {
     color: $cfa-experiment-purple;
     border-color: $cfa-experiment-purple;

--- a/_sass/_colors.scss
+++ b/_sass/_colors.scss
@@ -36,6 +36,8 @@ $cfa-alpha-blue: #78B5D8;
 $cfa-beta-blue: #004A6B;
 $cfa-offical-green: #00A274;
 
+$meetup-red: #e0393e;
+
 // primary colors
 $color-primary:            $oa-orange; // orange
 $color-primary-light:      #f2884b; // light orange

--- a/_sass/_colors.scss
+++ b/_sass/_colors.scss
@@ -26,10 +26,10 @@ $oa-gray:   #5D5D5D;
 $oa-grey:   $oa-gray;
 $oa-blue:   #0082DE;
 
-$cfa-red: #cf1b41;
+$cfa-red:  #cf1b41;
 $cfa-blue: #329ED5;
 $cfa-gray: #6D6E71;
-$cfa-grey:   $cfa-gray;
+$cfa-grey: $cfa-gray;
 
 $cfa-experiment-purple: #69559E;
 $cfa-alpha-blue: #78B5D8;

--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -12,7 +12,6 @@
     }
     .upcoming-events {
         padding: 30px 0;
-        width: $narrow-content-width;
     }
     h2 {
         text-align: center;

--- a/_sass/_meetup.scss
+++ b/_sass/_meetup.scss
@@ -1,11 +1,7 @@
 #meetup-widget {
 
-    h2 {
-        margin-top: 30px;
-    }
-
     .meetup-row {
-        padding: 20px 0;
+        padding: 20px 5%;
         border-bottom: 1px solid #e5e5e6;
         &:last-child {
             border-bottom: none;
@@ -16,10 +12,43 @@
         font-size: 24px;
     }
 
+    .url-placeholder {
+        width: 100%;
+        background-color: $color-neutral-light-gray;
+    }
+
     .date {
         float: right;
         text-align: right;
         color: #87807f;
+    }
+
+    .meetup-cal {
+      width: 100px;
+      margin: 15px 20px 10px 0;
+      border: 1px solid #c8c8c8;
+      box-shadow: 0px 1px 3px rgba(195, 193, 193, 0.8);
+      text-align: center;
+      float: left;
+    }
+
+    .meetup-month {
+      background: $meetup-red;
+      color: $color-neutral-white;
+      font-size: 24px;
+    }
+
+    .meetup-cal-body {
+      padding-bottom: 5px;
+    }
+
+    .meetup-day {
+      font-size: 36px;
+    }
+
+    .meetup-weekday {
+      font-size: 14px;
+      margin-top: -5px;
     }
 
     .description {
@@ -42,26 +71,14 @@
                 display: none;
             }
         }
-        .fade-out {
-            position: absolute;
-            z-index: 1;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            text-align: center;
-            margin: 0;
-            padding: 30px 0;
-            /* "transparent" only works here because == rgba(0,0,0,0) */
-            background-image: linear-gradient(to bottom, transparent, white);
-        }
     }
     .rsvp {
-        $meetup-red: #e0393e;
         display: block;
         font-size: 13px;
         margin: 0 0 10px;
         z-index: 2;
         position: relative;
+        text-align: right;
         a {
             background: #fff;
             padding: 5px 10px;

--- a/_sass/_meetup.scss
+++ b/_sass/_meetup.scss
@@ -1,4 +1,6 @@
 #meetup-widget {
+    max-width: 550px;
+    margin: 0 auto;
 
     .meetup-row {
         padding: 20px 5%;
@@ -18,14 +20,17 @@
     }
 
     .date {
-        float: right;
-        text-align: right;
-        color: #87807f;
+        color: $oa-gray;
     }
 
-    .meetup-cal {
+    .meetup-calendar {
+      flex: 1;
+      max-width: 120px;
+    }
+
+    .meetup-cal-container {
       width: 100px;
-      margin: 15px 20px 10px 0;
+      margin: 3px 20px 10px 0;
       border: 1px solid #c8c8c8;
       box-shadow: 0px 1px 3px rgba(195, 193, 193, 0.8);
       text-align: center;
@@ -55,7 +60,7 @@
         $meetup-font-size: 13px;
         $meetup-lines-to-show: 5;
         $meetup-line-height: 1.9;
-        color: #605b5a;
+        color: $oa-gray;
         padding: 10px 0;
         max-height: $meetup-lines-to-show * $meetup-font-size * $meetup-line-height;
         font-size: $meetup-font-size;
@@ -78,9 +83,8 @@
         margin: 0 0 10px;
         z-index: 2;
         position: relative;
-        text-align: right;
         a {
-            background: #fff;
+            background: $color-neutral-white;
             padding: 5px 10px;
             border-radius: 3px;
             text-decoration: none;
@@ -89,13 +93,27 @@
             background: white;
             &:hover {
                 border: 1px solid $meetup-red;
-                color: #fff;
+                color: $color-neutral-white;
                 background: $meetup-red;
             }
         }
         .count {
-            margin-right: 10px;
-            color: #87807f;
+            color: $oa-gray;
+            margin-left: 10px;
         }
     }
+    .fade-out {
+      position: absolute;
+      z-index: 1;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      text-align: center;
+      margin: 0;
+      padding: 20px 0;
+      /* "transparent" only works here because == rgba(0,0,0,0) */
+      background: -webkit-linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);
+      background: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);
+      background-color: rgba(255,255,255,0);
+  }
 }

--- a/_site/feed.xml
+++ b/_site/feed.xml
@@ -6,8 +6,8 @@
 </description>
     <link>http://open-austin.github.io/open-austin-org/</link>
     <atom:link href="http://open-austin.github.io/open-austin-org/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Sun, 14 Feb 2016 20:59:01 -0600</pubDate>
-    <lastBuildDate>Sun, 14 Feb 2016 20:59:01 -0600</lastBuildDate>
+    <pubDate>Sun, 14 Feb 2016 23:03:09 -0600</pubDate>
+    <lastBuildDate>Sun, 14 Feb 2016 23:03:09 -0600</lastBuildDate>
     <generator>Jekyll v2.5.3</generator>
     
       <item>

--- a/_site/feed.xml
+++ b/_site/feed.xml
@@ -6,8 +6,8 @@
 </description>
     <link>http://open-austin.github.io/open-austin-org/</link>
     <atom:link href="http://open-austin.github.io/open-austin-org/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Sun, 14 Feb 2016 23:03:09 -0600</pubDate>
-    <lastBuildDate>Sun, 14 Feb 2016 23:03:09 -0600</lastBuildDate>
+    <pubDate>Mon, 15 Feb 2016 20:33:14 -0600</pubDate>
+    <lastBuildDate>Mon, 15 Feb 2016 20:33:14 -0600</lastBuildDate>
     <generator>Jekyll v2.5.3</generator>
     
       <item>

--- a/assets/js/meetup.js
+++ b/assets/js/meetup.js
@@ -1,6 +1,14 @@
 (function() {
     // http://microjs.com/#
 
+    var monthsArray = [
+      "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"
+    ]
+
+    var weekdaysArray = [
+      "sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"
+    ]
+
     // pegasus is from https://github.com/typicode/pegasus
     function pegasus(a, xhr) {
         xhr = new XMLHttpRequest();
@@ -34,7 +42,9 @@
         var template = document.querySelector('#meetup-widget-template').innerHTML;
         data.results = data.results.slice(0, 1);
         data.results = data.results.map(function(result) {
-            result.prettyDate = new Date(result.time).toDateString();
+            result.month = monthsArray[new Date(result.time).getMonth()].toUpperCase();
+            result.day = new Date(result.time).getDate();
+            result.weekday = weekdaysArray[new Date(result.time).getDay()];
             return result;
         })
         var rendered = Mustache.render(template, data);
@@ -47,5 +57,5 @@
     }
 
     pegasus('https://lhtgmc37pi.execute-api.us-west-2.amazonaws.com/prod/meetup-proxy-aws-lambda')
-    .then(onSuccess, onError);
+    .then(onSuccess, onError)
 })();

--- a/assets/js/meetup.js
+++ b/assets/js/meetup.js
@@ -42,6 +42,7 @@
         var template = document.querySelector('#meetup-widget-template').innerHTML;
         data.results = data.results.slice(0, 1);
         data.results = data.results.map(function(result) {
+            result.prettyDate = new Date(result.time).toDateString();
             result.month = monthsArray[new Date(result.time).getMonth()].toUpperCase();
             result.day = new Date(result.time).getDate();
             result.weekday = weekdaysArray[new Date(result.time).getDay()];
@@ -57,5 +58,5 @@
     }
 
     pegasus('https://lhtgmc37pi.execute-api.us-west-2.amazonaws.com/prod/meetup-proxy-aws-lambda')
-    .then(onSuccess, onError)
+    .then(onSuccess, onError);
 })();

--- a/css/main.scss
+++ b/css/main.scss
@@ -4,7 +4,6 @@
 @charset "utf-8";
 
 // Import partials from `sass_dir` (defaults to `_sass`)
-@import "meetup";
 @import "variables";
 @import "colors";
 @import "media-query";


### PR DESCRIPTION
@VictoriaODell: You might hate this idea but what do you think about making the date more prominent with this little calendar component?

![screen shot 2016-02-14 at 11 03 38 pm](https://cloud.githubusercontent.com/assets/5697474/13040311/43e2c778-d370-11e5-87b8-704034ad2ec3.png)

Alternatively, with a few tweeks, this could work well for showing a pair of upcoming meetup events:
![screen shot 2016-02-14 at 11 08 33 pm](https://cloud.githubusercontent.com/assets/5697474/13040320/5caa9b8c-d370-11e5-9037-29b94eb7ccfc.png)

@luqmaan, I dropped the `.fade-out` because it breaks on Safari... Looked for a fix but got stuck.
<img width="845" alt="screen shot 2016-02-14 at 9 30 02 pm" src="https://cloud.githubusercontent.com/assets/5697474/13040350/8f189c4a-d370-11e5-8142-a7857161cadf.png">
