### PR TITLE
Fixing pagination

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -212,4 +212,6 @@ article.post {
 
 .pagination {
   clear: both;
+  padding-top: $spacing-unit / 2;
+  padding-bottom: $spacing-unit / 2;
 }

--- a/blog/index.html
+++ b/blog/index.html
@@ -39,7 +39,10 @@ title: Blog
     {% if paginator.previous_page %}
       <a href="{{ site.baseurl }}{{ paginator.previous_page_path }}" class="previous">Previous</a>
     {% else %}
-      <span class="previous">Previous</span>
+      {% if paginator.page == 1 %}
+      {% else %}
+        <span class="previous">Previous</span>
+      {% endif%}
     {% endif %}
     <span class="page_number ">Page: {{ paginator.page }} of {{ paginator.total_pages }}</span>
     {% if paginator.next_page %}
@@ -48,7 +51,7 @@ title: Blog
       <span class="next ">Next</span>
     {% endif %}
   </div>
-
+  
 </article>
 
 </div>


### PR DESCRIPTION
Fixes #82 
- added a little bit of liquid logic so that the word _Previous_ doesn't render on the first page.
- added `padding-top` and `padding-bottom` to the `.pagination` class

This addresses 2 of the 4 items in the #82 issue list. I think some of the other outstanding suggestions might need design feedback, but I'll be willing to help with those once a design decision comes around.
