### PR TITLE
Moving the How to Draft a Blog Post instructions to a Github Wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,54 +2,12 @@
 
 ### The Open Austin website
 
-- [How to Contribute a Blog Post](#how-to-draft-a-blog-post)
+- [How to Draft a Blog Post](https://github.com/open-austin/open-austin.github.io/wiki/How-to-Draft-a-Blog-Post)
 - [Development Instructions](#development-instructions)
 - [Planning](#planning)
 - [License](#license)
 
 ------------------
-
-# How to Draft a Blog Post
-
-There are three primary options:
-- _(Easiest)_ Draft it as a markdown file or Google doc and send it to @mateoclarke or @luqmaan.
-- _(Hardest)_ Clone the `open-austin-org` repo to your local computer and submit your draft via a Pull Request to `master`. I use an app called [MacDown](http://macdown.uranusjr.com/) to edit Markdown files. The main advantage to this option is that you can preview what the post will look like on your local machine before deploying.
-- _(Recommended)_ Try drafting it on Github.com
-
-### How to draft on Github.com
-  1. Go to: https://github.com/open-austin/open-austin.github.io/tree/master/_posts
-  2. Create a new file (see image)
-<img width="1117" alt="screen shot 2016-03-07 at 2 36 01 pm" src="https://cloud.githubusercontent.com/assets/5697474/13582507/664d0c70-e472-11e5-81b1-7cf8bba3ad40.png">
-
-  3. name the file `YYYY-MM-DD-title-of-article.md` 
-    - EX: `open-austin.github.io/_posts/2016-03-10-code-across-austin-2016-recap.md`
-![screen shot 2016-03-10 at 12 33 00 am](https://cloud.githubusercontent.com/assets/5697474/13662346/5b1af58a-e65f-11e5-9e2e-ddae4b2292e0.png)
-  4. Use the template below at the top of your new markdown file. (It's called [YML Front Matter](https://jekyllrb.com/docs/frontmatter/)). 
-
-        ---
-        layout: post
-        title: Title of your article
-        date: YYYY-MM-DD
-        type: post
-        published: true
-        thumb: filename.jpg
-        thumbalt: Alt text describing the thumbnail
-        author:
-          first_name: First
-          last_name: Last
-        ---
-        Begin your the body content of your post here. Use markdown syntax.
-        
-  5. Draft the body of the post below the `---` in [Markdown](https://guides.github.com/features/mastering-markdown/) and/or HTML (Markdown compiles to HTML).
-  6. Upload the thumbnail image (aka: featured image) you specified in the front matter to the [assets/images directory](https://github.com/open-austin/open-austin.github.io/tree/master/assets/images). You should be able to click the "Upload files" button.
-    - All other photos you want to include in the body of the post also need to be uploaded here and referenced in the post as `![alt text describing the image](/assets/images/imagefile-name.jpg)`.
-    - Thumbnail images shouldn't be wider than `250px`.
-    - Body images shouldn't be wider than `778px` but `500px` is recommended.
-![upload-photos](https://cloud.githubusercontent.com/assets/5697474/13662320/2f826098-e65f-11e5-9f51-995188a8fd10.png)
-![screen shot 2016-03-10 at 12 42 03 am](https://cloud.githubusercontent.com/assets/5697474/13662325/39d36e02-e65f-11e5-9f99-f0e94baf1545.png)
-  7. Once you are done drafting the file and uploading images, save your file creating a new branch, opening a pull request and requesting someone to review and merge. 
-    - OR Publish it straight to `master`. Do this if you feel brave.
-<img width="872" alt="screen shot 2016-03-07 at 2 54 17 pm" src="https://cloud.githubusercontent.com/assets/5697474/13582973/ae1a74be-e474-11e5-9a2a-6acf1ded30a4.png">
 
 # Development Instructions
 


### PR DESCRIPTION
- Moved the Blog Post instructions to [here](https://github.com/open-austin/open-austin.github.io/wiki/How-to-Draft-a-Blog-Post)
- Changed the link in the README.md
- Renamed the instructions in the README.md to `How to Draft a Blog Post`, to keep consistent across all references
- Removed the Blog Post instructions from the README.md
