### PR TITLE
Fixing typo in `twitter_username`.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,7 +25,7 @@
           </div>
           <div class="list-row-mobile">
             <li>
-              <a href="https://twitter.com/{{ site.twitter_usernam }}">
+              <a href="https://twitter.com/{{ site.twitter_username }}">
                 <span class="footer-svg footer-svg-twitter">{% include icons/icon-twitter.svg %}</span>
               </a>
             </li>


### PR DESCRIPTION
Twitter wasn't being correctly linked due to a typo.
